### PR TITLE
Fixing landscape spinner for iOS

### DIFF
--- a/src/ios/CDVSpinnerDialog.m
+++ b/src/ios/CDVSpinnerDialog.m
@@ -22,10 +22,17 @@
 @synthesize indicator = _indicator;
 @synthesize overlay = _overlay;
 
+-(CGRect)rectForView {
+    if (UIInterfaceOrientationIsLandscape([[UIDevice currentDevice] orientation])) {
+        return CGRectMake( 0.0f, 0.0f, [[UIScreen mainScreen]bounds].size.height, [UIScreen mainScreen].bounds.size.width);
+    }
+    return CGRectMake( 0.0f, 0.0f, [[UIScreen mainScreen]bounds].size.width, [UIScreen mainScreen].bounds.size.height);
+}
+
     
 -(UIView *)overlay {
     if (!_overlay) {
-        _overlay = [[UIView alloc] initWithFrame:[UIScreen mainScreen].bounds];
+        _overlay = [[UIView alloc] initWithFrame:self.rectForView];
         _overlay.backgroundColor = [UIColor colorWithRed:0 green:0 blue:0 alpha:0.25];
         _indicator = [[UIActivityIndicatorView alloc] initWithActivityIndicatorStyle:UIActivityIndicatorViewStyleWhiteLarge];
         _indicator.center = _overlay.center;


### PR DESCRIPTION
[UIScreen mainScreen].bounds does not respect orientation.

Effect:
![bildschirmfoto 2014-03-25 um 20 04 22](https://f.cloud.github.com/assets/1731415/2516681/7b372b38-b450-11e3-9229-5105133c3ab9.png)

I took the solution from here: http://stackoverflow.com/a/12825439
