### PR TITLE
A few fixes and enhancements for iOS and WP8

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ or
 
 - __title__: Spinner title (Android only). Optional. _(String)_
 - __message__: Spinner message. Optional. _(String)_
-- __cancelCallback__: Callback to invoke when spinner cancel event fired (tap or hardware back button event). If set, spinner dialog will be fixed, you should explicitly call `window.plugins.spinnerDialog.hide`. Due to legacy reasons you can provide boolean value (true/false) to set spinner not cancelable. Optional, defaults to `false`. _(Function/Boolean)_
+- __cancelCallback__: Callback to invoke when spinner cancel event fired (tap or Android hardware back button event). If set, spinner dialog will be fixed, you should explicitly call `window.plugins.spinnerDialog.hide`. Due to legacy reasons you can provide boolean value (true/false) to set spinner not cancelable. Optional, defaults to `false`. _(Function/Boolean)_
 
 
 ## Supported Platforms
@@ -36,23 +36,23 @@ or
     window.plugins.spinnerDialog.show();
     
     // Show spinner dialog with message 
-    // Note: spinner dialog is cancelable by default on Android and iOS. On WP8, it's fixed by deafult.
+    // Note: spinner dialog is cancelable by default
     window.plugins.spinnerDialog.show(null, "message");
     
-    // Set spinner dialog fixed (Android, iOS)
+    // Set spinner dialog fixed
     window.plugins.spinnerDialog.show(null, null, true);
     
-    // Set spinner dialog fixed with callback (Android, iOS)
-    // Note: callback fires on tap events and hardware back button click event
+    // Set spinner dialog fixed with callback
+    // Note: callback fires on tap events and Android hardware back button click event
     window.plugins.spinnerDialog.show(null, null, function () {console.log("callback");});
     
     // Show spinner dialog with title and message (Android only)
     window.plugins.spinnerDialog.show("title","message");
     
-    // Set spinner dialog fixed (cannot be canceled with screen touch or hardware button - Android only)
+    // Set spinner dialog fixed (cannot be canceled with screen touch or Android hardware button)
     window.plugins.spinnerDialog.show("title","message", true);
     
     // Hide spinner dialog
     window.plugins.spinnerDialog.hide();
     
-Note: on Android platfrom, multiple show calls builds up a stack (LIFO) which means hide will dismiss the last spinner added with show call. 
+Note: on Android platform, multiple show calls builds up a stack (LIFO) which means hide will dismiss the last spinner added with show call.

--- a/plugin.xml
+++ b/plugin.xml
@@ -2,7 +2,7 @@
 
 <plugin xmlns="http://cordova.apache.org/ns/plugins/1.0"
            id="hu.dpal.phonegap.plugins.SpinnerDialog"
-      version="1.2.1">
+      version="1.3.0">
 
     <name>SpinnerDialog</name>
     

--- a/src/ios/CDVSpinnerDialog.m
+++ b/src/ios/CDVSpinnerDialog.m
@@ -49,20 +49,20 @@
 - (UIView *)overlay {
     if (!_overlay) {
         _overlay = [[UIView alloc] initWithFrame:self.rectForView];
-        _overlay.backgroundColor = [UIColor colorWithRed:0 green:0 blue:0 alpha:0.25];
+        _overlay.backgroundColor = [UIColor colorWithRed:0 green:0 blue:0 alpha:0.35];
         _indicator = [[UIActivityIndicatorView alloc] initWithActivityIndicatorStyle:UIActivityIndicatorViewStyleWhiteLarge];
         _indicator.center = _overlay.center;
         [_indicator startAnimating];
         [_overlay addSubview:_indicator];
-        
+
         _messageView = [[UILabel alloc] initWithFrame: self.rectForView];
-        [_messageView setText: message];
+        [_messageView setText: message == nil ? title : message];
         [_messageView setTextColor: [UIColor colorWithRed:1 green:1 blue:1 alpha:0.85]];
         [_messageView setBackgroundColor: [UIColor colorWithRed:0 green:0 blue:0 alpha:0]];
         [_messageView setTextAlignment: NSTextAlignmentCenter];
          _messageView.center = (CGPoint){_overlay.center.x, _overlay.center.y + 40};
         [_overlay addSubview:_messageView];
-        
+
         UITapGestureRecognizer *tapRecognizer = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(handleTapGesture:)];
         [_overlay addGestureRecognizer: tapRecognizer];
     }
@@ -71,17 +71,17 @@
 
 
 - (void) show:(CDVInvokedUrlCommand*)command {
-    
+
     callbackId = command.callbackId;
-    
+
     title = [command argumentAtIndex:0];
     message = [command argumentAtIndex:1];
     isFixed = [command argumentAtIndex:2];
-    
+
     UIViewController *rootViewController = [[[[UIApplication sharedApplication] delegate] window] rootViewController];
-    
+
     [rootViewController.view addSubview:self.overlay];
-    
+
 }
 
 - (void) hide:(CDVInvokedUrlCommand*)command {

--- a/src/wp/SpinnerDialog.cs
+++ b/src/wp/SpinnerDialog.cs
@@ -1,6 +1,7 @@
 using Microsoft.Phone.Controls;
 using Microsoft.Phone.Shell;
 using System.Windows;
+using System.Windows.Input;
 
 namespace WPCordovaClassLib.Cordova.Commands
 {
@@ -16,10 +17,14 @@ namespace WPCordovaClassLib.Cordova.Commands
             string[] args = JSON.JsonHelper.Deserialize<string[]>(options);
             string title = args[0];
             string message = args[1];
+            string isFixed = args[2];
 
-            if (message == null)
+            if (message == null || "null".Equals(message))
             {
-                message = title;
+                if (title != null && !"null".Equals(title))
+                {
+                    message = title;
+                }
             }
 
             Deployment.Current.Dispatcher.BeginInvoke(() =>
@@ -37,10 +42,21 @@ namespace WPCordovaClassLib.Cordova.Commands
                     page = (Application.Current.RootVisual as PhoneApplicationFrame).Content as PhoneApplicationPage;
                 }
 
+                if (isFixed == null || "false".Equals(isFixed))
+                {
+                    page.MouseLeftButtonUp += ButtonEventHandler;
+                }
+
                 SystemTray.SetProgressIndicator(page, progressIndicator);
 
             });
 
+        }
+
+        private void ButtonEventHandler(object sender, MouseButtonEventArgs e)
+        {
+            hide(null);
+            DispatchCommandResult(new PluginResult(PluginResult.Status.OK));
         }
 
         public void hide(string options)
@@ -51,6 +67,7 @@ namespace WPCordovaClassLib.Cordova.Commands
                 Deployment.Current.Dispatcher.BeginInvoke(() =>
                 {
                     SystemTray.SetProgressIndicator(page, null);
+                    page.MouseLeftButtonUp -= ButtonEventHandler;
                 });
             }
 


### PR DESCRIPTION
- iOS and WP8 now show the title if message is null and title was passed (on iOS it was absent, on WP8 it showed the text 'null')
- WP8: implemented tap to cancel (like on the other platforms)
- WP8: implemented invocation of cancel callback
- Slightly darker iOS background
- REAME update to reflect these changes

Enjoy,
Eddy
