### PR TITLE
WP full screen compatibility

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -2,7 +2,7 @@
 
 <plugin xmlns="http://cordova.apache.org/ns/plugins/1.0"
            id="hu.dpal.phonegap.plugins.SpinnerDialog"
-      version="1.3.0">
+      version="1.3.1">
 
     <name>SpinnerDialog</name>
     

--- a/src/wp/SpinnerDialog.cs
+++ b/src/wp/SpinnerDialog.cs
@@ -10,6 +10,8 @@ namespace WPCordovaClassLib.Cordova.Commands
 
         private static ProgressIndicator progressIndicator;
         private static PhoneApplicationPage page;
+        private static bool sysTrayVisibilityDetermined;
+        private static bool sysTrayVisible;
 
         public void show(string options)
         {
@@ -49,6 +51,19 @@ namespace WPCordovaClassLib.Cordova.Commands
 
                 SystemTray.SetProgressIndicator(page, progressIndicator);
 
+                // determine systray visibility on first visit
+                if (!sysTrayVisibilityDetermined)
+                {
+                    sysTrayVisible = SystemTray.IsVisible;
+                    sysTrayVisibilityDetermined = true;
+                }
+
+                // show the tray if it's not visible, otherwise the spinner won't show up
+                if (!sysTrayVisible)
+                {
+                    SystemTray.IsVisible = true;
+                }
+
             });
 
         }
@@ -66,6 +81,11 @@ namespace WPCordovaClassLib.Cordova.Commands
             {
                 Deployment.Current.Dispatcher.BeginInvoke(() =>
                 {
+                    if (!sysTrayVisible)
+                    {
+                        SystemTray.IsVisible = false;
+                    }
+
                     SystemTray.SetProgressIndicator(page, null);
                     page.MouseLeftButtonUp -= ButtonEventHandler;
                 });


### PR DESCRIPTION
Hi, I've created a quick fix for this issue by temporarily showing the system tray (which includes the progress indicator (spinner)) when `show` is invoked. It's hidden again when the spinner itself is hidden.