### PR TITLE
Overlay opacity and message text color options added for ios

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,19 @@ or ```<gap:plugin name="hu.dpal.phonegap.plugins.spinnerdialog" source="plugins.
     // Set spinner dialog fixed (cannot be canceled with screen touch or Android hardware button)
     window.plugins.spinnerDialog.show("title","message", true);
     
+    // Overlay opacity and text color options (IOS only)
+    window.plugins.spinnerDialog.show(null,"Message",true, {overlayOpacity: 0.35,  textColorRed: 1, textColorGreen: 1, textColorBlue: 1}); 
+    
+    // Change only overlay opacity (IOS only)
+    window.plugins.spinnerDialog.show(null,"Message",true,{overlayOpacity:0.70});
+    
+    // Change only text color (IOS only)
+    window.plugins.spinnerDialog.show(null,"message",true, { textColorRed: 0.1, textColorGreen: 0.1, textColorBlue: 1});
+    
+    
     // Hide spinner dialog
     window.plugins.spinnerDialog.hide();
-    
+            
+ 
+  
 Note: on Android platform, multiple show calls builds up a stack (LIFO) which means hide will dismiss the last spinner added with show call.

--- a/src/ios/CDVSpinnerDialog.m
+++ b/src/ios/CDVSpinnerDialog.m
@@ -13,6 +13,10 @@
     NSString *title;
     NSString *message;
     NSNumber *isFixed;
+    NSString *alpha;
+    NSString *red;
+    NSString *green;
+    NSString *blue;
 }
 
 @property (nonatomic, retain) UIActivityIndicatorView *indicator;
@@ -49,7 +53,7 @@
 - (UIView *)overlay {
     if (!_overlay) {
         _overlay = [[UIView alloc] initWithFrame:self.rectForView];
-        _overlay.backgroundColor = [UIColor colorWithRed:0 green:0 blue:0 alpha:0.35];
+        _overlay.backgroundColor = [UIColor colorWithRed:0 green:0 blue:0 alpha:[alpha floatValue]];
         _indicator = [[UIActivityIndicatorView alloc] initWithActivityIndicatorStyle:UIActivityIndicatorViewStyleWhiteLarge];
         _indicator.center = _overlay.center;
         [_indicator startAnimating];
@@ -57,7 +61,7 @@
 
         _messageView = [[UILabel alloc] initWithFrame: self.rectForView];
         [_messageView setText: message == nil ? title : message];
-        [_messageView setTextColor: [UIColor colorWithRed:1 green:1 blue:1 alpha:0.85]];
+        [_messageView setTextColor: [UIColor colorWithRed:[red floatValue] green:[green floatValue] blue:[blue floatValue] alpha:0.85]];
         [_messageView setBackgroundColor: [UIColor colorWithRed:0 green:0 blue:0 alpha:0]];
         [_messageView setTextAlignment: NSTextAlignmentCenter];
          _messageView.center = (CGPoint){_overlay.center.x, _overlay.center.y + 40};
@@ -77,7 +81,11 @@
     title = [command argumentAtIndex:0];
     message = [command argumentAtIndex:1];
     isFixed = [command argumentAtIndex:2];
-
+    alpha = [command argumentAtIndex:3];
+    red = [command argumentAtIndex:4];
+    green = [command argumentAtIndex:5];
+    blue = [command argumentAtIndex:6];
+    
     UIViewController *rootViewController = [[[[UIApplication sharedApplication] delegate] window] rootViewController];
 
     [rootViewController.view addSubview:self.overlay];

--- a/www/spinner.js
+++ b/www/spinner.js
@@ -2,16 +2,23 @@ var exec = require('cordova/exec');
 
 module.exports = {
 
-	show : function(title, message, cancelCallback) {
+    show: function (title, message, cancelCallback, iosOptions) {
         if (cancelCallback == true && typeof cancelCallback !== "function") {
-            cancelCallback = function () {};  
+            cancelCallback = function () { };
         }
-        cordova.exec(cancelCallback, null, 'SpinnerDialog', 'show', [ title, message, !!cancelCallback ]);
+        var isPlatformIos = (navigator.userAgent.match(/iPad/i)) == "iPad" || (navigator.userAgent.match(/iPhone/i)) == "iPhone" ? true : false;
+        var params = [title, message, !!cancelCallback];
+        if (isPlatformIos) {
+            if (typeof iosOptions != "object") {
+                iosOptions = { overlayOpacity: 0.35, textColorRed: 1, textColorGreen: 1, textColorBlue: 1 }
+            }
+            params = params.concat([(iosOptions.overlayOpacity || 0.35), (iosOptions.textColorRed || 1), (iosOptions.textColorGreen || 1), (iosOptions.textColorBlue || 1)])
+        }
+        cordova.exec(cancelCallback, null, 'SpinnerDialog', 'show', params);
+
     },
-
-
-    hide : function(success, fail) {
-        cordova.exec(success, fail, 'SpinnerDialog', 'hide', [ "","" ]);
+    hide: function (success, fail) {
+        cordova.exec(success, fail, 'SpinnerDialog', 'hide', ["", ""]);
     }
 
 };


### PR DESCRIPTION
1-) When the background is white on ios apps the message and also spinner cannot be seen because of the opacity of overlay. So I made the opacity of overlay as optional parameter. 
2-) Also I added optional text color for ios for better customization.   