### PR TITLE
Make the dialog background color transparent on Android 5.x

### DIFF
--- a/src/android/CallbackProgressDialog.java
+++ b/src/android/CallbackProgressDialog.java
@@ -7,6 +7,9 @@ import android.app.ProgressDialog;
 import android.content.Context;
 import android.view.MotionEvent;
 
+import android.graphics.Color;
+import android.graphics.drawable.ColorDrawable;
+
 public class CallbackProgressDialog extends ProgressDialog {
 
 	public static CallbackContext callbackContext;
@@ -26,6 +29,7 @@ public class CallbackProgressDialog extends ProgressDialog {
 		dialog.setIndeterminate(indeterminate);
 		dialog.setCancelable(cancelable);
 		dialog.setOnCancelListener(cancelListener);
+		dialog.getWindow().setBackgroundDrawable(new ColorDrawable(Color.TRANSPARENT));
 		dialog.show();
 		return dialog;
 	}


### PR DESCRIPTION
Currently this fix only works in "fixed" mode. Tested on Nexus 5X.
